### PR TITLE
[IOS] Move zlib import to allow module support

### DIFF
--- a/Godzippa/NSData+Godzippa.h
+++ b/Godzippa/NSData+Godzippa.h
@@ -22,8 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <zlib.h>
-
 /**
  Godzippa provides a category on `NSData` to inflate and deflate data using gzip compression.
  */

--- a/Godzippa/NSData+Godzippa.m
+++ b/Godzippa/NSData+Godzippa.m
@@ -22,6 +22,8 @@
 
 #import "NSData+Godzippa.h"
 
+#import <zlib.h>
+
 static const int kGodzippaChunkSize = 1024;
 static const int kGodzippaDefaultMemoryLevel = 8;
 static const int kGodzippaDefaultWindowBits = 15;

--- a/Godzippa/NSFileManager+Godzippa.h
+++ b/Godzippa/NSFileManager+Godzippa.h
@@ -22,8 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <zlib.h>
-
 /**
  Godzippa provides a category on `NSFileManager` to inflate and deflate files using gzip compression.
  */

--- a/Godzippa/NSFileManager+Godzippa.m
+++ b/Godzippa/NSFileManager+Godzippa.m
@@ -22,6 +22,8 @@
 
 #import "NSFileManager+Godzippa.h"
 
+#import <zlib.h>
+
 static const int kGodzippaChunkSize = 4096;
 
 @implementation NSFileManager (Godzippa)


### PR DESCRIPTION
- In order to support importing `Godzippa` as a module, we need to move the `zlib` import from the header file
- This is based off an [existing PR](https://github.com/mattt/Godzippa/pull/12) to `Godzippa` but it's been open for over a year